### PR TITLE
Allow for VM tcp service naming (temp solution)

### DIFF
--- a/proxy/envoy/mixer.go
+++ b/proxy/envoy/mixer.go
@@ -133,7 +133,9 @@ func mixerTCPConfig(role proxy.Node, check bool) *FilterMixerConfig {
 	if strings.HasPrefix(role.ID, "vm-") {
 		split := strings.SplitAfterN(role.ID, "-", 3)
 		if len(split) == 3 {
-			attr[AttrDestinationService] = split[2] + "." + role.Domain
+			// role.ID has the namespace and so does role.Domain (!), trim:
+			domainWithouNamespace := role.Domain[strings.Index(role.Domain, "."):]
+			attr[AttrDestinationService] = split[2] + domainWithouNamespace
 		}
 	}
 	return &FilterMixerConfig{

--- a/proxy/envoy/mixer.go
+++ b/proxy/envoy/mixer.go
@@ -129,11 +129,11 @@ func mixerTCPConfig(role proxy.Node, check bool) *FilterMixerConfig {
 		AttrDestinationIP:  role.IPAddress,
 		AttrDestinationUID: "kubernetes://" + role.ID,
 	}
-	// vm-NNN-rest -> service==rest
+	// vm-NNN-rest -> service==rest.domain (domain is needed for mixer)
 	if strings.HasPrefix(role.ID, "vm-") {
 		split := strings.SplitAfterN(role.ID, "-", 3)
 		if len(split) == 3 {
-			attr[AttrDestinationService] = split[2]
+			attr[AttrDestinationService] = split[2] + "." + role.Domain
 		}
 	}
 	return &FilterMixerConfig{


### PR DESCRIPTION
if the POD_NAME on a VM is set to`vm-xxx-yyy` destination service will
be set to `yyy` (so one can have say `vm-1-mysqldb`, `vm-2-mysqldb`,... participate in the `mysqldb` service)

This allows TCP services to work with mixer/avoids:
```
E1017 05:58:02.900969       1 grpcServer.go:181] Check returned with
error : INTERNAL (destination.service identity not found in
attributes[context.time destination.ip source.ip destination.uid
context.protocol source.port])
```

Rel note;
```release-note
Allows VM tcp service to be named (through POD_NAME=vm-xxx-servicename)
```